### PR TITLE
Asllib changes pr

### DIFF
--- a/lua/asllib.lua
+++ b/lua/asllib.lua
@@ -8,7 +8,8 @@ Asllib = {}
 -- closure to be computed when the value is called.
 function m1( fn, a, ... )
     if type(a) == 'function' then
-        return function() return m1( fn, a(), ... ) end -- recursive!
+        local t = {...}
+        return function() return fn( a(), table.unpack(t) ) end
     else
         return fn( a, ... )
     end
@@ -18,6 +19,7 @@ end
 function n2v( n ) return m1( function(a) return a/12 end, n ) end
 function negate( n ) return m1( function(a) return -a end, n ) end
 function clamp( input, min, max )
+    min, max = min or 0.005, max or 1e10
     return m1( function( a, b, c )
                  return math.min( math.max( b, a ), c )
                end
@@ -30,13 +32,15 @@ end
 -- TODO build this recursively with m1 above for n-args
 function m2( fn, a, b, ... )
     if type(a) == 'function' then
+        local t = {...}
         if type(b) == 'function' then
-            return function() return fn(a(),b(),...) end
+            return function() return fn(a(),b(),table.unpack(t)) end
         else
-            return function() return fn(a(),b,...) end
+            return function() return fn(a(),b,table.unpack(t)) end
         end
     elseif type(b) == 'function' then
-        return function() return fn(a,b(),...) end
+        local t = {...}
+        return function() return fn(a,b(),table.unpack(t)) end
     else
         return fn(a,b,...)
     end
@@ -51,7 +55,7 @@ end
 function lfo( time, level )
     time, level = time or 1, level or 5
 
-    local function half(t) = m1( function(a) return clamp(a/2) end, t )
+    local function half(t) return m1( function(a) return clamp(a/2) end, t ) end
 
     return loop{ to(        level , half(time) )
                , to( negate(level), half(time) )
@@ -71,9 +75,9 @@ function pulse( time, level, polarity )
                  , mag, pol)
     end
 
-    return{ to( active(level,pol) , 0 )
-          , to( 'here'            , clamp(time) )
-          , to( resting(level,pol), 0 )
+    return{ to( active(level,polarity) , 0 )
+          , to( 'here'                 , clamp(time) )
+          , to( resting(level,polarity), 0 )
           }
 end
 

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -86,14 +86,15 @@ function toward_handler( id ) end -- do nothing if Asl not active
 -- if defined, make sure active before setting up actions and banging
 if Asl then
     toward_handler = function( id )
+        print(collectgarbage('count'))
         output[id].asl:step()
     end
 end
 -- special wrapper should really be in the ASL lib itself?
 function LL_toward( id, d, t, s )
-    if type(d) == 'function' then d = d() end
-    if type(t) == 'function' then t = t() end
-    if type(s) == 'function' then s = s() end
+    while type(d) == 'function' do d = d() end
+    while type(t) == 'function' do t = t() end
+    while type(s) == 'function' do s = s() end
     go_toward( id, d, t, s )
 end
 


### PR DESCRIPTION
I'd just cherry-pick the bits you want from this rather than merging due to the conflict.

Principally
- the clamp function needs defaults (or it causes a super weird & confusing bug at runtime)
- need to capture a local copy of the varargs so they can be pulled into the closure.
- defn of `half` in `lfo` was wrong
- was using wrong var name in `pulse` which meant `polarity` was non-functional
- converted LL_toward to use `while` rather than `if` to recursively unwrap nested functions (perhaps this is what was causing crow crashes for me).

The big issue i was having (and why i didn't push this sooner bc i was trying to solve), is that i can run `ramp()` with default args, but after the 4th breakpoint, crow locks up with a hard-fault and i haven't been able to figure it out.